### PR TITLE
Implement dependency issue fix for Python 3.14

### DIFF
--- a/bibla/config.py
+++ b/bibla/config.py
@@ -1,7 +1,7 @@
 """Linter configuration logic."""
+import sys
 from typing import Dict, Any
 
-import pkg_resources
 import yaml
 
 _config = dict()
@@ -46,8 +46,13 @@ def load_config_file(file):
 def _load_default_config():
     global _read_default
     _read_default = True
-    with open(pkg_resources.resource_filename(__name__,
-                                              _DEFAULT_CONFIG_FILE)) as \
+    if sys.version_info >= (3, 9):
+        from importlib.resources import files
+        config_path = files('bibla') / _DEFAULT_CONFIG_FILE
+    else:
+        from pathlib import Path
+        config_path = Path(__file__).parent / _DEFAULT_CONFIG_FILE
+    with open(config_path) as \
             default_config_file:
         default_config = yaml.load(default_config_file, Loader=yaml.FullLoader)
         for k, v in default_config.items():

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,9 @@ setup(
         'click>=7',
         'fuzzywuzzy>=0.10',
         'markdown-table',
-        'pybtex==0.23.0',
+        'pybtex>=0.25.0',
         'pyyaml>=5',
         'unidecode>=1,<2',
-        'setuptools>= 69.0.0'
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
This pull request updates the configuration loading logic and dependency requirements to improve compatibility and maintainability. The main changes include replacing the use of `pkg_resources` with a more modern approach for accessing package resources, and updating a key dependency version in `setup.py`.

**Configuration loading improvements:**

* Replaced the use of `pkg_resources` with `importlib.resources` (for Python 3.9+) or `pathlib` (for older versions) in `_load_default_config`, making resource loading more robust and future-proof. (`bibla/config.py`) [[1]](diffhunk://#diff-425e9313c4dfafb42dd6473af868a24b3c8d725073454d29097729af28abd363R2-L4) [[2]](diffhunk://#diff-425e9313c4dfafb42dd6473af868a24b3c8d725073454d29097729af28abd363L49-R55)

**Dependency updates:**

* Updated the `pybtex` dependency from version `0.23.0` to `>=0.25.0` in `setup.py` to ensure compatibility with newer features and bug fixes.